### PR TITLE
Remove dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <kotlin.version>2.1.0</kotlin.version>
         <kotlinx-coroutines.version>1.10.1</kotlinx-coroutines.version>
         <spring-boot.version>3.4.3</spring-boot.version>
+        <reactor-kotlin-extensions.version>1.2.3</reactor-kotlin-extensions.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
@@ -57,35 +58,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <dependencies>
-        <!-- Spring Boot Core -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
-
-        <!-- Kotlin Dependencies -->
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-reflect</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlinx</groupId>
-            <artifactId>kotlinx-coroutines-core</artifactId>
-        </dependency>
-
-        <!-- Test Dependencies -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 
     <build>
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
         <kotlin.version>2.1.0</kotlin.version>
         <kotlinx-coroutines.version>1.10.1</kotlinx-coroutines.version>
         <spring-boot.version>3.4.3</spring-boot.version>
-        <reactor-kotlin-extensions.version>1.2.3</reactor-kotlin-extensions.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>


### PR DESCRIPTION
Remove dependencies from the parent POM. Parent POM will handle versions and configuration but let's keep dependencies in the application POMs